### PR TITLE
Implementation of search logic by sending params with getNeeds and getQuests requests

### DIFF
--- a/src/app/donation/needs/models/need.interface.ts
+++ b/src/app/donation/needs/models/need.interface.ts
@@ -1,8 +1,12 @@
 export interface Need {
+  id?: number;
+  orphanageID?: number;
   orphanageName: string;
   lastDateWhenStatusChanged: string;
   status: string;
   city: string;
   itemName: string;
+  itemDescription?: string;
+  types?: string[];
   donationItemID: number;
 }

--- a/src/app/donation/needs/needs-list/needs.component.html
+++ b/src/app/donation/needs/needs-list/needs.component.html
@@ -1,6 +1,5 @@
 <app-search
-  (onSearch)="onSearch($event)"></app-search>
-
+  (searchInit)="onSearch($event)"></app-search>
 <mat-list>
   <mat-list-item *ngFor="let need of needs$ | async; trackBy: trackById">
     <app-needs-item [need]="need"></app-needs-item>

--- a/src/app/donation/needs/needs-list/needs.component.ts
+++ b/src/app/donation/needs/needs-list/needs.component.ts
@@ -23,6 +23,6 @@ export class NeedsComponent implements OnInit {
   }
 
   public onSearch(searchValue: string): void {
-    this.needs$ = this.needService.getNeeds({ itemName: searchValue });
+    this.needs$ = this.needService.getNeeds({ forSearch: searchValue });
   }
 }

--- a/src/app/donation/needs/services/need.service.spec.ts
+++ b/src/app/donation/needs/services/need.service.spec.ts
@@ -1,11 +1,66 @@
-import { TestBed } from '@angular/core/testing';
 import { NeedService } from './need.service';
+import { Need } from '../models/need.interface';
+import { of } from 'rxjs';
+import { HttpParams } from '@angular/common/http';
 
-xdescribe('NeedsService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+describe('NeedService', () => {
+  let service: NeedService;
+  let httpClientSpy: { get: jasmine.Spy };
+  let configServiceSpy: { getConfig: jasmine.Spy };
+  let configUrl: {
+    needsApi: string
+  };
 
-  xit('should be created', () => {
-    const service: NeedService = TestBed.get(NeedService);
+  beforeEach(() => {
+    httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
+    configServiceSpy = jasmine.createSpyObj('configService', ['getConfig']);
+    service = new NeedService(httpClientSpy as any, configServiceSpy as any);
+    configUrl = {
+      needsApi: 'https://familynetserver.azurewebsites.net/api/v1/donations'
+    };
+    configServiceSpy.getConfig.and.returnValue(of(configUrl));
+  });
+
+  it('service should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  describe('Method getNeeds', () => {
+    let mockNeeds: Need[];
+    beforeEach(() => {
+      mockNeeds = [
+        {
+          id: 1, city: 'Днепр', orphanageID: 54, donationItemID: 1, status: 'Sended',
+          lastDateWhenStatusChanged: '2019-10-26T09:27:31.2431168',
+          orphanageName: 'NameS124', itemName: 'Футболка', itemDescription: 'Размер XS', types: []
+        },
+        {
+          id: 2, city: 'Днепр', orphanageID: 53, donationItemID: 2, status: 'Sended',
+          lastDateWhenStatusChanged: '2019-10-26T09:28:22.6096282',
+          orphanageName: 'CD100', itemName: 'Тапки', itemDescription: 'Тапки 48го размера', types: []
+        }
+      ];
+
+      httpClientSpy.get.and.returnValue(of(mockNeeds));
+    });
+
+    it('should get all Needs', (done: DoneFn) => {
+      service.getNeeds().subscribe((needs: Need[]) => {
+        expect(needs).toEqual(mockNeeds);
+        done();
+      });
+    });
+
+    it('should set search params to get request for needs list', (done: DoneFn) => {
+      const searchValue = 'Тапки';
+      let params = new HttpParams();
+      params = params.set('forSearch', searchValue);
+
+      service.getNeeds({ forSearch: searchValue }).subscribe((needs: Need[]) => {
+        expect(httpClientSpy.get).toHaveBeenCalledWith(configUrl.needsApi, { params });
+        done();
+      });
+    });
+  });
+
 });

--- a/src/app/donation/needs/services/need.service.ts
+++ b/src/app/donation/needs/services/need.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Need } from '../models/need.interface';
 import { Config } from 'src/app/shared/services/config/config.interface';
@@ -20,16 +20,10 @@ export class NeedService {
   // Nikolaienko Mikhail takes responsibility to negotiate with backers on matter of realization
   // of search logic on beckend until next presentation.
   public getNeeds(paramObj: object = {}): Observable<Need[]> {
+    let params = new HttpParams();
+    Object.keys(paramObj).forEach((key: string) => params = params.set(key, paramObj[key]));
     return this.configService.getConfig().pipe(
-      concatMap((config: Config) => this.http.get<Need[]>(config.needsApi)),
-      map((arr: Need[]): Need[] => {
-        if (Object.values(paramObj).length > 0) {
-          const key: string = Object.keys(paramObj)[0];
-          const value: string = paramObj[key];
-          return arr.filter((el: Need): boolean => el[key].toLowerCase().indexOf(value.toLocaleLowerCase()) > -1);
-        }
-        return arr;
-      })
+      concatMap((config: Config) => this.http.get<Need[]>(config.needsApi, { params }))
     );
   }
 

--- a/src/app/donation/needs/services/need.service.ts
+++ b/src/app/donation/needs/services/need.service.ts
@@ -15,10 +15,6 @@ export class NeedService {
     private http: HttpClient,
     private configService: ConfigService) { }
 
-  // TODO. Nikolaienko Mikhail responsible for realization of search logic.
-  // Due to lack of search logic on backend, it is temporary realized on front-side.
-  // Nikolaienko Mikhail takes responsibility to negotiate with backers on matter of realization
-  // of search logic on beckend until next presentation.
   public getNeeds(paramObj: object = {}): Observable<Need[]> {
     let params = new HttpParams();
     Object.keys(paramObj).forEach((key: string) => params = params.set(key, paramObj[key]));

--- a/src/app/donation/quests/models/quest.interface.ts
+++ b/src/app/donation/quests/models/quest.interface.ts
@@ -1,8 +1,12 @@
 export interface Quest {
+  id?: number;
+  orphanageID?: number;
+  charityMakerID?: number;
   orphanageName: string;
   lastDateWhenStatusChanged: string;
   status: string;
   city: string;
   itemName: string;
   itemID: number;
+  types: string[];
 }

--- a/src/app/donation/quests/quests-list/quests-list.component.html
+++ b/src/app/donation/quests/quests-list/quests-list.component.html
@@ -1,6 +1,5 @@
 <app-search
-  (onSearch)="onSearch($event)"></app-search>
-
+  (searchInit)="onSearch($event)"></app-search>
 <mat-list>
   <mat-list-item *ngFor="let quest of quests$ | async; trackBy: trackById">
     <app-quests-item [quest]="quest"></app-quests-item>

--- a/src/app/donation/quests/quests-list/quests-list.component.ts
+++ b/src/app/donation/quests/quests-list/quests-list.component.ts
@@ -15,7 +15,7 @@ export class QuestsListComponent implements OnInit {
   constructor(private questService: QuestService) { }
 
   public ngOnInit() {
-    this.quests$ = this.questService.getNeeds();
+    this.quests$ = this.questService.getQuests();
   }
 
   public trackById(index: number, quest: Quest): number {
@@ -23,6 +23,6 @@ export class QuestsListComponent implements OnInit {
   }
 
   public onSearch(searchValue: string): void {
-    this.quests$ = this.questService.getNeeds({ itemName: searchValue });
+    this.quests$ = this.questService.getQuests({ forSearch: searchValue });
   }
 }

--- a/src/app/donation/quests/services/quest.service.spec.ts
+++ b/src/app/donation/quests/services/quest.service.spec.ts
@@ -1,11 +1,66 @@
-import { TestBed } from '@angular/core/testing';
 import { QuestService } from './quest.service';
+import { Quest } from '../models/quest.interface';
+import { of } from 'rxjs';
+import { HttpParams } from '@angular/common/http';
 
-xdescribe('QuestService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+describe('QuestService', () => {
+  let service: QuestService;
+  let httpClientSpy: { get: jasmine.Spy };
+  let configServiceSpy: { getConfig: jasmine.Spy };
+  let configUrl: {
+    questsApi: string
+  };
 
-  xit('should be created', () => {
-    const service: QuestService = TestBed.get(QuestService);
+  beforeEach(() => {
+    httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
+    configServiceSpy = jasmine.createSpyObj('configService', ['getConfig']);
+    service = new QuestService(httpClientSpy as any, configServiceSpy as any);
+    configUrl = {
+      questsApi: 'https://familynetserver.azurewebsites.net/api/v1/quests'
+    };
+    configServiceSpy.getConfig.and.returnValue(of(configUrl));
+  });
+
+  it('service should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  describe('Method getQuests', () => {
+    let mockQuests: Quest[];
+    beforeEach(() => {
+      mockQuests = [
+        {
+          id: 1, city: 'Сумы', orphanageID: 54, charityMakerID: null, itemID: 1, status: 'Sended',
+          lastDateWhenStatusChanged: '2019-10-26T09:27:31.2431168', orphanageName: 'Эльф',
+          itemName: 'Покрасить забор', types: []
+        },
+        {
+          id: 2, city: 'Херсон', orphanageID: 53, charityMakerID: null, itemID: 2, status: 'Sended',
+          lastDateWhenStatusChanged: '2019-10-26T09:28:22.6096282', orphanageName: 'Ромашка',
+          itemName: 'Привезти материалы', types: []
+        }
+      ];
+
+      httpClientSpy.get.and.returnValue(of(mockQuests));
+    });
+
+    it('should get all Quests', (done: DoneFn) => {
+      service.getQuests().subscribe((quests: Quest[]) => {
+        expect(quests).toEqual(mockQuests);
+        done();
+      });
+    });
+
+    it('should set search params to get request for quests list', (done: DoneFn) => {
+      const searchValue = 'Тапки';
+      let params = new HttpParams();
+      params = params.set('forSearch', searchValue);
+
+      service.getQuests({ forSearch: searchValue }).subscribe((quests: Quest[]) => {
+        expect(httpClientSpy.get).toHaveBeenCalledWith(configUrl.questsApi, { params });
+        done();
+      });
+    });
+  });
+
 });

--- a/src/app/donation/quests/services/quest.service.ts
+++ b/src/app/donation/quests/services/quest.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Quest } from '../models/quest.interface';
 import { concatMap, map } from 'rxjs/operators';
@@ -15,21 +15,11 @@ export class QuestService {
     private http: HttpClient,
     private configService: ConfigService) { }
 
-  // TODO. Nikolaienko Mikhail responsible for realization of search logic.
-  // Due to lack of search logic on backend, it is temporary realized on front-side.
-  // Nikolaienko Mikhail takes responsibility to negotiate with backers on matter of realization
-  // of search logic on beckend until next presentation.
-  public getNeeds(paramObj: object = {}): Observable<Quest[]> {
+  public getQuests(paramObj: object = {}): Observable<Quest[]> {
+    let params = new HttpParams();
+    Object.keys(paramObj).forEach((key: string) => params = params.set(key, paramObj[key]));
     return this.configService.getConfig().pipe(
-      concatMap((config: Config) => this.http.get<Quest[]>(config.questsApi)),
-      map((arr: Quest[]): Quest[] => {
-        if (Object.values(paramObj).length > 0) {
-          const key: string = Object.keys(paramObj)[0];
-          const value: string = paramObj[key];
-          return arr.filter((el: Quest): boolean => el[key].toLowerCase().indexOf(value.toLocaleLowerCase()) > -1);
-        }
-        return arr;
-      })
+      concatMap((config: Config) => this.http.get<Quest[]>(config.questsApi, { params })),
     );
   }
 }

--- a/src/app/shelters/shelters-service/shelters.service.spec.ts
+++ b/src/app/shelters/shelters-service/shelters.service.spec.ts
@@ -17,13 +17,13 @@ describe('SheltersService', () => {
   beforeEach(() => {
     httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
     configServiceSpy = jasmine.createSpyObj('configService', ['getConfig']);
-    service = new SheltersService(<any>httpClientSpy, <any>configServiceSpy);
+    service = new SheltersService(httpClientSpy as any, configServiceSpy as any);
     configUrl = {
-      "sheltersApi": "https://familynetserver.azurewebsites.net/api/v1/childrenHouse",
-      "childrenApi": "https://familynetserver.azurewebsites.net/api/v1/children/",
-      "representativesApi": "https://familynetserver.azurewebsites.net/api/v1/representatives/",
-      "addressApi": "https://familynetserver.azurewebsites.net/api/v1/address"
-    }
+      sheltersApi: 'https://familynetserver.azurewebsites.net/api/v1/childrenHouse',
+      childrenApi: 'https://familynetserver.azurewebsites.net/api/v1/children/',
+      representativesApi: 'https://familynetserver.azurewebsites.net/api/v1/representatives/',
+      addressApi: 'https://familynetserver.azurewebsites.net/api/v1/address'
+    };
     configServiceSpy.getConfig.and.returnValue(of(configUrl));
   });
 
@@ -36,27 +36,35 @@ describe('SheltersService', () => {
     let mockShelters: Shelter[];
     beforeEach(() => {
       mockAnswerForApi = {
-        "https://familynetserver.azurewebsites.net/api/v1/childrenHouse": [
-          { "id": 53, "name": "Ромашка", "adressID": 114, "rating": 11.0 },
-          { "id": 54, "name": "Лопухи", "adressID": 115, "rating": 12.0 }
+        'https://familynetserver.azurewebsites.net/api/v1/childrenHouse': [
+          { id: 53, name: 'Ромашка', adressID: 114, rating: 11.0 },
+          { id: 54, name: 'Лопухи', adressID: 115, rating: 12.0 }
         ],
-        "https://familynetserver.azurewebsites.net/api/v1/children/": [
-          { "id": 110, "name": "Глеб", "surname": "Левада", "patronymic": "Русланович", "childrenHouseID": 53, "childrenHouseName": "Ромашка" },
-          { "id": 111, "name": "Олег", "surname": "Курасов", "patronymic": "Михайлович", "childrenHouseID": 54, "childrenHouseName": "Лопухи" },
+        'https://familynetserver.azurewebsites.net/api/v1/children/': [
+          { id: 110, name: 'Глеб', surname: 'Левада', patronymic: 'Русланович', childrenHouseID: 53, childrenHouseName: 'Ромашка' },
+          { id: 111, name: 'Олег', surname: 'Курасов', patronymic: 'Михайлович', childrenHouseID: 54, childrenHouseName: 'Лопухи' },
         ],
-        "https://familynetserver.azurewebsites.net/api/v1/representatives/" : [
-          {"id":54,"name":"Олег","surname":"Петренко","patronymic":"Дмитреевич", "childrenHouseID":53 },
-          {"id":55,"name":"Марина","surname":"Кричич","patronymic":"Михайловна", "childrenHouseID":54 }
+        'https://familynetserver.azurewebsites.net/api/v1/representatives/': [
+          { id: 54, name: 'Олег', surname: 'Петренко', patronymic: 'Дмитреевич', childrenHouseID: 53 },
+          { id: 55, name: 'Марина', surname: 'Кричич', patronymic: 'Михайловна', childrenHouseID: 54 }
         ],
-        "https://familynetserver.azurewebsites.net/api/v1/address": [
-          {"id":114,"country":"Украина","region":"Днепропетровская","city":"Днепр","street":"Артема","house":"250"},
-          {"id":115,"country":"Украина","region":"Днепропетровская","city":"Днепр","street":"Гагарина","house":"122"}
+        'https://familynetserver.azurewebsites.net/api/v1/address': [
+          { id: 114, country: 'Украина', region: 'Днепропетровская', city: 'Днепр', street: 'Артема', house: '250' },
+          { id: 115, country: 'Украина', region: 'Днепропетровская', city: 'Днепр', street: 'Гагарина', house: '122' }
         ]
       };
 
-      mockShelters = [  
-        { id: 53, name: "Ромашка", adressID: 114, rating: 11.0, children: 1, representative: { id: 54, name: 'Олег', surname: 'Петренко', patronymic: 'Дмитреевич', childrenHouseID: 53 }, address: { id: 114, country: 'Украина', region: 'Днепропетровская', city: 'Днепр', street: 'Артема', house: '250' } },
-        { id: 54, name: 'Лопухи', adressID: 115, rating: 12, children: 1, representative: { id: 55, name: 'Марина', surname: 'Кричич', patronymic: 'Михайловна', childrenHouseID: 54 }, address: { id: 115, country: 'Украина', region: 'Днепропетровская', city: 'Днепр', street: 'Гагарина', house: '122' }}];
+      mockShelters = [
+        {
+          id: 53, name: 'Ромашка', adressID: 114, rating: 11.0, children: 1,
+          representative: { id: 54, name: 'Олег', surname: 'Петренко', patronymic: 'Дмитреевич', childrenHouseID: 53 },
+          address: { id: 114, country: 'Украина', region: 'Днепропетровская', city: 'Днепр', street: 'Артема', house: '250' }
+        },
+        {
+          id: 54, name: 'Лопухи', adressID: 115, rating: 12, children: 1,
+          representative: { id: 55, name: 'Марина', surname: 'Кричич', patronymic: 'Михайловна', childrenHouseID: 54 },
+          address: { id: 115, country: 'Украина', region: 'Днепропетровская', city: 'Днепр', street: 'Гагарина', house: '122' }
+        }];
 
       configServiceSpy.getConfig.and.returnValue(of(configUrl));
       httpClientSpy.get.and.callFake(api => of(mockAnswerForApi[api]));
@@ -70,9 +78,9 @@ describe('SheltersService', () => {
     });
 
     it('should set search params to get request for shelter list', (done: DoneFn) => {
-      const searchValue = "Ромашка";
+      const searchValue = 'Ромашка';
       let params = new HttpParams();
-      params = params.set("name", searchValue);
+      params = params.set('name', searchValue);
 
       service.getShelters({ name: searchValue }).subscribe((shelters: Shelter[]) => {
         expect(httpClientSpy.get).toHaveBeenCalledWith(configUrl.sheltersApi, { params });

--- a/src/app/shelters/shelters-service/shelters.service.spec.ts
+++ b/src/app/shelters/shelters-service/shelters.service.spec.ts
@@ -32,7 +32,7 @@ describe('SheltersService', () => {
   });
 
   describe('Method getShelters', () => {
-    let mockAnswerForApi: object;
+    let mockAnswerForApi: any;
     let mockShelters: Shelter[];
     beforeEach(() => {
       mockAnswerForApi = {
@@ -66,7 +66,6 @@ describe('SheltersService', () => {
           address: { id: 115, country: 'Украина', region: 'Днепропетровская', city: 'Днепр', street: 'Гагарина', house: '122' }
         }];
 
-      configServiceSpy.getConfig.and.returnValue(of(configUrl));
       httpClientSpy.get.and.callFake(api => of(mockAnswerForApi[api]));
     });
 

--- a/src/app/shelters/shelters-service/shelters.service.ts
+++ b/src/app/shelters/shelters-service/shelters.service.ts
@@ -19,7 +19,6 @@ export class SheltersService {
   public getShelters(paramObj: object = {}): Observable<Shelter[]> {
     let params = new HttpParams();
     Object.keys(paramObj).forEach((key: string) => params = params.set(key, paramObj[key]));
-    
     return this.configService.getConfig().pipe(
       concatMap((config: Config) =>
         zip(


### PR DESCRIPTION
Reworking logic of searching in Needs and Quests component. Now we sending params to transfer search functionality on side of back.
Tests for methods of services which have search logic.
Small fixes of ng lint errors.