### PR TITLE
Changed the displayed message for the login and registration

### DIFF
--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -66,7 +66,7 @@ export class LoginComponent implements OnInit, OnDestroy {
           }
         },
         error => {
-          this.notifier.showNotice(error.message, 'error');
+          this.notifier.showNotice(error.error || 'Something bad happened, please try again later.', 'error');
         }
       );
   }

--- a/src/app/user-registration/user-registration.component.ts
+++ b/src/app/user-registration/user-registration.component.ts
@@ -67,7 +67,7 @@ export class UserRegistrationComponent implements OnInit, OnDestroy {
             .subscribe(() => this.router.navigate(['/user-info']));
         },
         error => {
-          this.notifier.showNotice(error.message, 'error');
+          this.notifier.showNotice(error.error || 'Something bad happened, please try again later.', 'error');
         }
       );
   }


### PR DESCRIPTION
**error.message ⇒ error.error and added the default message**

before:
![error1](https://user-images.githubusercontent.com/47761397/69242011-a9d5e500-0ba8-11ea-9dd8-35c2d8401014.PNG)

after:
![error2](https://user-images.githubusercontent.com/47761397/69242028-afcbc600-0ba8-11ea-92da-a11378c95d7a.PNG)
